### PR TITLE
Simplify add_periods_before_capitals()

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -13,16 +13,16 @@
 // For example: "Sentence one Xentence two Sentence three " becomes "Sentence one. Xentence two. Sentence three "
 static void add_periods_before_capitals(char *line) 
 {
-    if (!line)
+    size_t length = strlen(line);
+    if (!line || length == 0)
         return;
 
-    size_t length = strlen(line);
     size_t buff_len = length;
     
     // Count periods required to then allocate with correct size
     for (size_t i = 1; i < length - 1; i++)
     {
-        if (line[i - 1] != '.' && line[i] == ' ' && isupper(line[i + 1]))
+        if (isalpha(line[i - 1]) && line[i] == ' ' && isupper(line[i + 1]))
         {
             buff_len += 1;
         }
@@ -30,26 +30,20 @@ static void add_periods_before_capitals(char *line)
 
 
     char* buff = (char*)malloc(buff_len + 1);
-    
     if (!buff)
     {
         return;
     }
     
-    int buff_index = 0;
-    
-    for (size_t i = 0; i < length; i++)
+    buff[0] = line[0];
+    int buff_index = 1;
+    for (size_t i = 1; i < length; i++)
     {
-        buff[buff_index++] = line[i];
-        
-        if (i == 0 || i == length - 1)
-            continue;
-
-        if (line[i - 1] != '.' && line[i] == ' ' && isupper(line[i + 1]))
+        if (isalpha(line[i - 1]) && line[i] == ' ' && isupper(line[i + 1]))
         {
-            buff[buff_index - 1] = '.';
-            buff[buff_index++] = ' ';
+            buff[buff_index++] = '.';
         }
+        buff[buff_index++] = line[i];
     }
     
     buff[buff_index] = '\0';

--- a/utils.c
+++ b/utils.c
@@ -10,6 +10,11 @@
 #define MAX_LINE_LENGTH 256
 #define MAX_LINES 1000
 
+static bool needs_period_before_capitol(char* line, size_t i)
+{
+    return isalpha(line[i - 1]) && line[i] == ' ' && isupper(line[i + 1]);
+}
+
 // For example: "Sentence one Xentence two Sentence three " becomes "Sentence one. Xentence two. Sentence three "
 static void add_periods_before_capitals(char *line) 
 {
@@ -23,7 +28,7 @@ static void add_periods_before_capitals(char *line)
     // Count periods required to then allocate with correct size
     for (size_t i = 1; i < length - 1; i++)
     {
-        if (isalpha(line[i - 1]) && line[i] == ' ' && isupper(line[i + 1]))
+        if (needs_period_before_capitol(line, i))
         {
             buff_len += 1;
         }
@@ -40,7 +45,7 @@ static void add_periods_before_capitals(char *line)
     
     for (size_t i = 1; i < length; i++)
     {
-        if (isalpha(line[i - 1]) && line[i] == ' ' && isupper(line[i + 1]))
+        if (needs_period_before_capitol(line, i))
         {
             buff[buff_index++] = '.';
         }

--- a/utils.c
+++ b/utils.c
@@ -14,6 +14,7 @@
 static void add_periods_before_capitals(char *line) 
 {
     size_t length = strlen(line);
+    
     if (!line || length == 0)
         return;
 
@@ -28,21 +29,22 @@ static void add_periods_before_capitals(char *line)
         }
     }
 
-
     char* buff = (char*)malloc(buff_len + 1);
+    
     if (!buff)
-    {
         return;
-    }
     
     buff[0] = line[0];
+    
     int buff_index = 1;
+    
     for (size_t i = 1; i < length; i++)
     {
         if (isalpha(line[i - 1]) && line[i] == ' ' && isupper(line[i + 1]))
         {
             buff[buff_index++] = '.';
         }
+        
         buff[buff_index++] = line[i];
     }
     


### PR DESCRIPTION
* Added checking for `line` `length == 0`
* Use `isalpha()` to check prev character
* Simplify loop code

The following inputs were tested:
```
    char str1[100] = "the red fox jumped over the fence";
    char str2[100] = "the red fox jumped over the fence Sentence one Sentence two Sentence three";
    char str3[100] = "";
    char str4[100] = "    the red fox jumped over the fence    A";
```
Note that before this change the `str4` input would cause a dot before `A` character. Now dot is not placed due to `isalpha()` usage.  In future all excessive spaces in `line` should be trimmed.